### PR TITLE
add --trust option to easily complete short PVs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,6 +28,8 @@ To this end the following scripts are provided:
 * `provepvs.py`: uses conjectured PVs to guide a local engine to find mates and
   prove PVs (the scripts works sequentially, proven PVs are available
   immediately)
+* `shortenpvs.py`: removes moves from the end of existing PVs (only used in
+  development, for debugging other scripts)
 * `sortbymates.py`: sorts the positions in an EPD file
 
 By way of example, the following EPD files are provided:

--- a/provepvs.py
+++ b/provepvs.py
@@ -24,29 +24,28 @@ def pv_status(fen, mate, pv):
 
 class Analyser:
     def __init__(self, args):
-        self.engine = args.engine
+        self.engine = chess.engine.SimpleEngine.popen_uci(args.engine)
+        if args.hash is not None:
+            self.engine.configure({"Hash": args.hash})
+        if args.threads is not None:
+            self.engine.configure({"Threads": args.threads})
+        if args.syzygyPath is not None:
+            self.engine.configure({"SyzygyPath": args.syzygyPath})
         self.limit = chess.engine.Limit(
             nodes=args.nodes, depth=args.depth, time=args.time, mate=args.mate
         )
-        self.hash = args.hash
-        self.threads = args.threads
-        self.syzygyPath = args.syzygyPath
         self.depthMin = args.depthMin
         self.depthMax = args.depthMax
         self.nodesFill = args.nodesFill
         self.timeFill = args.timeFill
 
+    def quit(self):
+        self.engine.quit()
+
     def analyze_fen(self, fen, bm, pv):
-        engine = chess.engine.SimpleEngine.popen_uci(self.engine)
-        if self.hash is not None:
-            engine.configure({"Hash": self.hash})
-        if self.threads is not None:
-            engine.configure({"Threads": self.threads})
-        if self.syzygyPath is not None:
-            engine.configure({"SyzygyPath": self.syzygyPath})
         board = chess.Board(fen)
         # first clear hash with a simple d1 search
-        engine.analyse(board, chess.engine.Limit(depth=1), game=board)
+        self.engine.analyse(board, chess.engine.Limit(depth=1), game=board)
         # now walk to PV leaf node
         ply = 0
         for move in pv:
@@ -57,7 +56,7 @@ class Analyser:
         while board.move_stack:
             if bool(board.legal_moves):
                 depth = min(args.depthMax, max_ply - ply + args.depthMin)
-                info = engine.analyse(
+                info = self.engine.analyse(
                     board,
                     chess.engine.Limit(
                         depth=depth, nodes=self.nodesFill, time=self.timeFill
@@ -76,7 +75,7 @@ class Analyser:
             ply -= 1
 
         # finally do the actual analysis, to try to prove the mate
-        info = engine.analyse(board, self.limit, game=board)
+        info = self.engine.analyse(board, self.limit, game=board)
         m, pv = None, None
         if "score" in info:
             score = info["score"].pov(board.turn)
@@ -86,8 +85,6 @@ class Analyser:
             print(f"Final score {score}, mate {m} (d{depth}, nodes {nodes})")
         if m is not None and abs(m) <= abs(bm) and "pv" in info:
             pv = [m.uci() for m in info["pv"]]
-
-        engine.quit()
 
         return m, pv
 
@@ -106,6 +103,11 @@ if __name__ == "__main__":
         "--cdbFile",
         default="../cdbmatetrack/matetrack_cdbpv.epd",
         help="file with conjectured mate PVs",
+    )
+    parser.add_argument(
+        "--trust",
+        action="store_true",
+        help="take the conjectured PVs as proven (use with care!)",
     )
     parser.add_argument(
         "--outFile",
@@ -232,6 +234,7 @@ if __name__ == "__main__":
 
     ana = Analyser(args)
 
+    count = 0
     with open(args.outFile, "w") as f:
         for i, (fen, bm, pv, oldpv) in enumerate(ana_fens):
             print(f'Analysing {i+1}/{total_count} "{fen}" with bm #{bm}...', flush=True)
@@ -257,3 +260,7 @@ if __name__ == "__main__":
                 f.write(f"{fen} bm #{bm}; PV: {' '.join(pv)};\n")
                 f.close()
                 f = open(args.outFile, "a")
+                count += 1
+
+    ana.quit()
+    print(f"All done. Saved {count} PVs to {args.outFile}.")

--- a/provepvs.py
+++ b/provepvs.py
@@ -51,8 +51,9 @@ class Analyser:
         ply, pvmate = 0, bm
         for move in pv:
             board.push(chess.Move.from_uci(move))
-            pvmate = -pvmate + (1 if pvmate > 0 else 0)
             ply += 1
+            pvmate = -pvmate + (1 if pvmate > 0 else 0)
+
         # now do a backward analysis, filling the hash table
         max_ply = ply
         while board.move_stack:
@@ -77,11 +78,11 @@ class Analyser:
                         m = score.mate()
                         if m is not None and m > 0 and m <= pvmate and "pv" in info:
                             print(f"Found terminal mate {m}, ending search early.")
-                            return bm + m - pvmate, pv + [m.uci() for m in info["pv"]]
-                        pvmate = -pvmate + (1 if pvmate < 0 else 0)
+                            return bm + m - pvmate, pv[:ply] + [m.uci() for m in info["pv"]]
 
             board.pop()
             ply -= 1
+            pvmate = -pvmate + (1 if pvmate <= 0 else 0)
 
         # finally do the actual analysis, to try to prove the mate
         info = self.engine.analyse(board, self.limit, game=board)

--- a/provepvs.py
+++ b/provepvs.py
@@ -78,6 +78,7 @@ class Analyser:
                         if m is not None and m > 0 and m <= pvmate and "pv" in info:
                             print(f"Found terminal mate {m}, ending search early.")
                             return bm + m - pvmate, pv + [m.uci() for m in info["pv"]]
+                        pvmate = -pvmate + (1 if pvmate < 0 else 0)
 
             board.pop()
             ply -= 1

--- a/provepvs.py
+++ b/provepvs.py
@@ -78,10 +78,14 @@ class Analyser:
                         m = score.mate()
                         # we play this safe and only use positive mate scores
                         if m is not None and m > 0 and m <= pvmate and "pv" in info:
-                            print(f"Found terminal mate {m}, ending search early.")
-                            return bm + m - pvmate, pv[:ply] + [
-                                m.uci() for m in info["pv"]
-                            ]
+                            newbm = bm + m - pvmate
+                            newpv = pv[:ply] + [m.uci() for m in info["pv"]]
+                            status = pv_status(fen, newbm, newpv)
+                            print(
+                                f"Found terminal mate {m}, combined PV has status {status}."
+                            )
+                            assert status in ["ok", "short"], f"Unexpected PV status."
+                            return newbm, newpv
 
             board.pop()
             ply -= 1
@@ -268,6 +272,8 @@ if __name__ == "__main__":
                         f"PV has length {len(pv)} <= {len(oldpv)}, so no improvement."
                     )
                     pv = None
+                else:
+                    print(f"PV has length {len(pv)} > {len(oldpv)}.")
             if pv is not None:
                 print("Save PV to file.")
                 f.write(f"{fen} bm #{bm}; PV: {' '.join(pv)};\n")

--- a/provepvs.py
+++ b/provepvs.py
@@ -76,9 +76,12 @@ class Analyser:
                     )
                     if self.trust:
                         m = score.mate()
+                        # we play this safe and only use positive mate scores
                         if m is not None and m > 0 and m <= pvmate and "pv" in info:
                             print(f"Found terminal mate {m}, ending search early.")
-                            return bm + m - pvmate, pv[:ply] + [m.uci() for m in info["pv"]]
+                            return bm + m - pvmate, pv[:ply] + [
+                                m.uci() for m in info["pv"]
+                            ]
 
             board.pop()
             ply -= 1

--- a/shortenpvs.py
+++ b/shortenpvs.py
@@ -1,0 +1,51 @@
+import argparse, chess, random, re
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Shorten existing PVs by removing moves from the end.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--epdFile",
+        default="matetrackpv.epd",
+        help="file containing the positions, their mate scores and their PVs",
+    )
+    parser.add_argument(
+        "--outFile",
+        default="shortpvs.epd",
+        help="output file with shortened PVs",
+    )
+    parser.add_argument(
+        "--plies",
+        type=int,
+        default=1,
+        help="number of plies to remove, if possible",
+    )
+    parser.add_argument(
+        "--random",
+        action="store_true",
+        help="remove random number X of plies, with X in [0, PLIES].",
+    )
+    args = parser.parse_args()
+
+    p = re.compile("([0-9a-zA-Z/\- ]*) bm #([0-9\-]*);")
+
+    fens = count = 0
+    with open(args.epdFile) as fin, open(args.outFile, "w") as fout:
+        for line in fin:
+            m = p.match(line)
+            assert m, f"error for line '{line[:-1]}' in file {args.epdFile}"
+            fen, bm = m.group(1), int(m.group(2))
+            _, _, pv = line.partition("; PV: ")
+            pv, _, _ = pv[:-1].partition(";")  # remove '\n'
+            pv = pv.split()
+            plies = random.randint(0, args.plies) if args.random else args.plies
+            if plies == 0 or plies >= len(pv):
+                fout.write(line)
+            else:
+                fout.write(f"{fen} bm #{bm}; PV: {' '.join(pv[:-plies])};\n")
+                count += 1
+            fens += 1
+
+    print(f"Loaded {fens} FENs, shortened {count} PVs.")


### PR DESCRIPTION
Sample usage:

```
> python provepvs.py --trust --epdFile matetrack.epd --cdbFile matetrackpv.epd --mateType all --timeFill 1
Found 6506 PVs we can use to try to prove/find mate PVs ...
Analysing 1/6506 "5K2/8/2qk4/2nPp3/3r4/6B1/B7/3R4 w - e6" with bm #1...
Final score #+1, mate 1 (d245, nodes 35292)
Found mate #1!
PV has length 1 > 0.
Save PV to file.
.
.
.
Analysing 6506/6506 "8/ppp1P1p1/8/8/3p4/8/1ppp2K1/br2k2n w - -" with bm #89...
ply 152, score -633 (d15, nodes 61352)
ply 151, score 0 (d16, nodes 21878)
ply 150, score 0 (d17, nodes 14451)
ply 149, score 0 (d18, nodes 3743)
ply 148, score 0 (d19, nodes 47187)
ply 147, score 0 (d20, nodes 5675)
ply 146, score 0 (d21, nodes 9293)
ply 145, score 0 (d22, nodes 11525)
ply 144, score 0 (d23, nodes 7898)
ply 143, score 0 (d24, nodes 54280)
ply 142, score 0 (d25, nodes 20055)
ply 141, score 0 (d26, nodes 25662)
ply 140, score 0 (d27, nodes 46799)
ply 139, score #-19 (d28, nodes 88470)
ply 138, score #+20 (d29, nodes 60443)
Found terminal mate 20, combined PV has status ok.
Found mate #89!
PV has length 177 > 0.
Save PV to file.
All done. Saved 6501 PVs to provenpvs.epd.
```