### PR TITLE
bug fix

### DIFF
--- a/matetb.py
+++ b/matetb.py
@@ -1,6 +1,6 @@
 import argparse, chess, collections, time
 
-VALUE_MATE = 1000  # larger values mean more iterations when no mate can be found
+VALUE_MATE = 30000
 
 
 def score2mate(score):
@@ -99,13 +99,7 @@ class MateTB:
         self.tb = [None] * dim
         for fen, idx in self.fen2index.items():
             board = chess.Board(fen)
-            score = (
-                -VALUE_MATE
-                if board.is_checkmate()
-                else 0
-                if board.is_stalemate() or board.is_insufficient_material()
-                else None
-            )
+            score = -VALUE_MATE if board.is_checkmate() else 0
             children = []
             for move in board.legal_moves:
                 board.push(move)
@@ -130,7 +124,7 @@ class MateTB:
                     score = self.tb[child][0]
                     if score:
                         score = -score + (1 if score > 0 else -1)
-                    if score is not None and (best_score is None or score > best_score):
+                    if best_score is None or score > best_score:
                         best_score = score
                 if best_score is not None and self.tb[i][0] != best_score:
                     self.tb[i][0] = best_score
@@ -222,22 +216,22 @@ def fill_exclude_options(args):
     epd = " ".join(args.epd.split()[:4])
     if epd in [
         "8/8/8/1p6/6k1/1p2Q3/p1p1p3/rbrbK3 w - -",  # bm #36 (success)
-        "8/8/8/1p6/6k1/1Q6/p1p1p3/rbrbK3 b - -", # bm #-35 (success)
+        "8/8/8/1p6/6k1/1Q6/p1p1p3/rbrbK3 b - -",  # bm #-35 (success)
     ]:
         args.excludeFrom = "e1"
         args.excludeTo = "a1 c1"
         args.excludeToAttacked = True
-    elif epd == "7k/8/5p2/8/8/8/P1Kp1pp1/4brrb w - -": # bm #43 (success)
+    elif epd == "7k/8/5p2/8/8/8/P1Kp1pp1/4brrb w - -":  # bm #43 (success)
         args.firstMove = "c2d1"
         args.excludeFrom = "d1"
         args.excludeToAttacked = True
-    elif epd == "8/1p6/8/3p3k/3p4/6Q1/pp1p4/rrbK4 w - -": # bm #46 (success)
+    elif epd == "8/1p6/8/3p3k/3p4/6Q1/pp1p4/rrbK4 w - -":  # bm #46 (success)
         args.excludeFrom = "d1"
         args.excludeCaptures = True
         args.excludeToAttacked = True
     elif epd in [
-        "8/1p6/4k3/8/3p1Q2/3p4/pp1p4/rrbK4 w - -", # bm #56 (success)
-        "8/6pp/5p2/k7/3p4/1Q2p3/3prpp1/3Kbqrb w - -", # bm #57 (success)
+        "8/1p6/4k3/8/3p1Q2/3p4/pp1p4/rrbK4 w - -",  # bm #56 (success)
+        "8/6pp/5p2/k7/3p4/1Q2p3/3prpp1/3Kbqrb w - -",  # bm #57 (success)
     ]:
         args.excludeFrom = "d1"
         args.excludeToAttacked = True


### PR DESCRIPTION
Initialze TB with drawscore for all non-checkmate positions, rather than with `None` for non-terminal draws.

The bug in main lead to some draws going undetected. Example main:
```
Running with options --epd "8/p7/8/8/8/3p1b2/pp1K1N2/qk6 w - -" --excludeFrom d2 --excludeToCapturable
Create the allowed part of the game tree ...
Found 35394 positions in 5.14s
Connect child nodes and score leaf positions ...
Connected 35394 positions in 2.81s
Generate tablebase ...
Tablebase generated with 253 iterations in 4.49s

Matetrack:
8/p7/8/8/8/3p1b2/pp1K1N2/qk6 w - - bm #14; PV: f2h3 f3a8 h3f4 a8b7 f4e6 b7d5 e6d8 d5a8 d8f7 a8d5 f7e5 d5g8 e5c6 g8c4 c6a7 c4a6 a7c6 a6c8 c6d8 c8d7 d8f7 d7e8 f7d6 e8f7 d6b5 f7g8 b5c3;
```
with the wrong move `e6d8`, leading to a draw.

Patch:
```
Running with options --epd "8/p7/8/8/8/3p1b2/pp1K1N2/qk6 w - -" --excludeFrom d2 --excludeToCapturable
Create the allowed part of the game tree ...
Found 35394 positions in 5.44s
Connect child nodes and score leaf positions ...
Connected 35394 positions in 2.84s
Generate tablebase ...
Tablebase generated with 10 iterations in 0.17s

Matetrack:
8/p7/8/8/8/3p1b2/pp1K1N2/qk6 w - - bm #18; PV: f2h3 f3a8 h3f4 a8b7 f4e6 b7d5 e6g7 d5g8 g7e8 g8d5 e8d6 a7a6 d6e8 d5a8 e8c7 a8b7 c7e6 b7a8 e6c5 a8c6 c5a6 c6e8 a6c7 e8c6 c7e6 c6e8 e6d8 e8f7 d8b7 f7g8 b7d6 g8h7 d6b5 h7g8 b5c3;
```