### PR TITLE
add parameters for mate 54 position

### DIFF
--- a/matetb.py
+++ b/matetb.py
@@ -394,8 +394,8 @@ def fill_exclude_options(args):
     elif epd == "8/7p/7p/7p/1p3Q1p/1Kp5/nppr4/qrk5 w - -":  # bm #54 (not yet)
         args.excludeFrom = "b3"
         args.excludeAllowingCapture = True
-        args.excludeAllowingFrom = "b1"
-        args.excludeAllowingMoves = "h2h1 c3c2 c2c1"
+        args.excludeAllowingFrom = "b1 h1"
+        args.excludeAllowingMoves = "c3c2 c2c1"
 
 
 if __name__ == "__main__":

--- a/matetb.py
+++ b/matetb.py
@@ -391,7 +391,7 @@ def fill_exclude_options(args):
         args.excludeAllowingCapture = True
         args.excludeAllowingFrom = "g1"
         args.excludeAllowingMoves = "e6e5 e5e4"
-    elif epd == "8/7p/7p/7p/1p3Q1p/1Kp5/nppr4/qrk5 w - -":  # bm #54 (not yet)
+    elif epd == "8/7p/7p/7p/1p3Q1p/1Kp5/nppr4/qrk5 w - -":  # bm #54
         args.excludeFrom = "b3"
         args.excludeAllowingCapture = True
         args.excludeAllowingFrom = "b1 h1"


### PR DESCRIPTION
This now gives
```
> pypy3 matetb.py --epd "8/7p/7p/7p/1p3Q1p/1Kp5/nppr4/qrk5 w - -"
Running with options --epd "8/7p/7p/7p/1p3Q1p/1Kp5/nppr4/qrk5 w - -" --excludeFrom b3 --excludeAllowingCapture --excludeAllowingFrom "b1 h1" --excludeAllowingMoves "c3c2 c2c1"
Restrict moves for WHITE side.
Create the allowed part of the game tree ...
Found 18372009 positions in 2755.44s
Connect child nodes ...
Connected 18372009 positions in 1810.30s
Generate tablebase ...
Tablebase generated with 44 iterations in 368.13s

Matetrack:
8/7p/7p/7p/1p3Q1p/1Kp5/nppr4/qrk5 w - - bm #54; PV: f4f1 d2d1 f1f2 d1d2 f2f4 h4h3 f4f1 d2d1 f1f2 d1d2 f2f4 h5h4 f4f1 d2d1 f1f2 d1d2 f2f4 h6h5 f4f1 d2d1 f1f2 d1d2 f2f4 h7h6 f4f1 d2d1 f1f2 d1d2 f2f4 h3h2 f4f1 d2d1 f1g2 d1d2 g2h1 d2d1 h1h2 d1d2 h2f4 h4h3 f4f1 d2d1 f1f2 d1d2 f2f4 h5h4 f4f1 d2d1 f1f2 d1d2 f2f4 h6h5 f4f1 d2d1 f1f2 d1d2 f2f4 h3h2 f4f1 d2d1 f1g2 d1d2 g2h1 d2d1 h1h2 d1d2 h2f4 h4h3 f4f1 d2d1 f1f2 d1d2 f2f4 h5h4 f4f1 d2d1 f1f2 d1d2 f2f4 h3h2 f4f1 d2d1 f1g2 d1d2 g2h1 d2d1 h1h2 d1d2 h2f4 h4h3 f4f1 d2d1 f1f2 d1d2 f2f4 h3h2 f4f1 d2d1 f1g2 d1d2 g2h1 d2d1 h1h2 d1d2 h2f4 c1d1 f4f1;
```