### PR TITLE
add option --excludeAllowingSANs

### DIFF
--- a/matetb.py
+++ b/matetb.py
@@ -47,11 +47,15 @@ class MateTB:
             if args.excludeAllowingMoves is None
             else args.excludeAllowingMoves.split()
         )
+        self.excludeAllowingSANs = (
+            [] if args.excludeAllowingSANs is None else args.excludeAllowingSANs.split()
+        )
         self.needToGenerateResponses = (
             args.excludeAllowingCapture
             or self.BBexcludeAllowingFrom
             or self.BBexcludeAllowingTo
             or self.excludeAllowingMoves
+            or self.excludeAllowingSANs
         )
         self.verbose = args.verbose
         self.prepare_opening_book(args.openingMoves)
@@ -115,6 +119,7 @@ class MateTB:
                     or (self.BBexcludeAllowingFrom & (1 << m.from_square))
                     or (self.BBexcludeAllowingTo & (1 << m.to_square))
                     or (m.uci() in self.excludeAllowingMoves)
+                    or (board.san(m) in self.excludeAllowingSANs)
                 ):
                     board.pop()
                     return False
@@ -281,6 +286,7 @@ def fill_exclude_options(args):
         or args.excludeAllowingFrom
         or args.excludeAllowingTo
         or args.excludeAllowingMoves
+        or args.excludeAllowingSANs
     ):
         return
     epd = " ".join(args.epd.split()[:4])
@@ -442,6 +448,15 @@ def fill_exclude_options(args):
         args.excludeTo = "h1"
         args.excludeAllowingCapture = True
         args.excludeAllowingFrom = "b3 h5 h4"
+    elif epd in [
+        "8/p7/8/p7/b3Q3/K7/p1r5/rk6 w - -",  # bm #10
+        "8/p7/8/p7/b3Q3/K6p/p1r5/rk6 w - -",  # bm #22
+    ]:
+        args.excludeFrom = "a3"
+        args.excludeTo = "a1"
+        args.excludeAllowingCapture = True
+        args.excludeAllowingFrom = "a1 h1"
+        args.excludeAllowingSANs = "Kb1 Kc2 Kd1 Kd2"
 
 
 if __name__ == "__main__":
@@ -495,7 +510,11 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--excludeAllowingMoves",
-        help="Space separated moves that opponent should not be allowed to make in reply to our move.",
+        help="Space separated UCI moves that opponent should not be allowed to make in reply to our move.",
+    )
+    parser.add_argument(
+        "--excludeAllowingSANs",
+        help="Space separated SAN moves that opponent should not be allowed to make in reply to our move.",
     )
     parser.add_argument(
         "--outFile",
@@ -522,6 +541,7 @@ if __name__ == "__main__":
         ("excludeAllowingFrom", args.excludeAllowingFrom),
         ("excludeAllowingTo", args.excludeAllowingTo),
         ("excludeAllowingMoves", args.excludeAllowingMoves),
+        ("excludeAllowingSANs", args.excludeAllowingSANs),
     ]
     options = " ".join(
         [


### PR DESCRIPTION
Sometimes UCI notation is not fine grained enough to restrict moves just to certain pieces. In the example below, we just want to prevent the black king to escape from c1, while allowing the rook to move freely from c1.

```
> pypy3 matetb.py --epd "8/p7/8/p7/b3Q3/K7/p1r5/rk6 w - -"
Running with options --epd "8/p7/8/p7/b3Q3/K7/p1r5/rk6 w - -" --excludeFrom a3 --excludeTo a1 --excludeAllowingCapture --excludeAllowingFrom "a1 h1" --excludeAllowingSANs "Kb1 Kc2 Kd1 Kd2"
Restrict moves for WHITE side.
Create the allowed part of the game tree ...
Found 666025 positions in 259.17s
Connect child nodes ...
Connected 666025 positions in 81.27s
Generate tablebase ...
Tablebase generated with 12 iterations in 5.14s

Matetrack:
8/p7/8/p7/b3Q3/K7/p1r5/rk6 w - - bm #10; PV: e4h1 c2c1 h1h7 c1c2 h7e4 a7a6 e4h1 c2c1 h1h7 c1c2 h7e4 a4e8 e4e1 c2c1 e1d2 c1c3 d2c3 e8f7 c3b2;
```