### PR TITLE
never send game=board in backward analysis

### DIFF
--- a/provenpvs.epd
+++ b/provenpvs.epd
@@ -1,0 +1,1 @@
+8/7p/7p/7p/1p3Q1p/1Kp5/nppr4/qrk5 w - - bm #54; PV: f4f1 d2d1 f1f2 d1d2 f2f4 h4h3 f4f1 d2d1 f1f2 d1d2 f2f4 h5h4 f4f1 d2d1 f1f2 d1d2 f2f4 h6h5 f4f1 d2d1 f1f2 d1d2 f2f4 h7h6;

--- a/provenpvs.epd
+++ b/provenpvs.epd
@@ -1,1 +1,0 @@
-8/7p/7p/7p/1p3Q1p/1Kp5/nppr4/qrk5 w - - bm #54; PV: f4f1 d2d1 f1f2 d1d2 f2f4 h4h3 f4f1 d2d1 f1f2 d1d2 f2f4 h5h4 f4f1 d2d1 f1f2 d1d2 f2f4 h6h5 f4f1 d2d1 f1f2 d1d2 f2f4 h7h6;

--- a/provepvs.py
+++ b/provepvs.py
@@ -75,7 +75,7 @@ class Analyser:
                     f'Analysing "{board.epd()}" (after move {board.peek().uci()}) to {limit}.',
                     flush=True,
                 )
-                info = self.engine.analyse(board, limit, game=board)
+                info = self.engine.analyse(board, limit)
                 if "score" in info:
                     score = info["score"].pov(board.turn)
                     depth = info["depth"] if "depth" in info else None
@@ -121,7 +121,7 @@ class Analyser:
                 f'Analysing "{board.epd()}" to {limit}.',
                 flush=True,
             )
-            info = self.engine.analyse(board, limit, game=board)
+            info = self.engine.analyse(board, limit)
             m, pv = None, None
             if "score" in info:
                 score = info["score"].pov(board.turn)


### PR DESCRIPTION
The [help](https://python-chess.readthedocs.io/en/latest/engine.html#chess.engine.Protocol.analyseP) says: 
```
game Optional. An arbitrary object that identifies the game. Will automatically inform the engine if the object is not equal to the previous game (e.g., ucinewgame, new).
```

Better safe than sorry: from now on never risk any hash clearing in backward analysis.