### PR TITLE
filter UCI output to not include upperbound or lowerbound

### DIFF
--- a/addpvs.py
+++ b/addpvs.py
@@ -31,6 +31,15 @@ def pv_status(fen, mate, pv):
     return "wrong"
 
 
+def filtered_analysis(engine, board, limit=None, game=None):
+    info = {}
+    with engine.analysis(board, limit, game=game) as analysis:
+        for line in analysis:
+            if "score" in line and not ("upperbound" in line or "lowerbound" in line):
+                info = line
+    return info
+
+
 class Analyser:
     def __init__(self, args):
         self.engine = args.engine
@@ -53,7 +62,7 @@ class Analyser:
         for fen, bm, pvlength, line in fens:
             pv = None
             board = chess.Board(fen)
-            info = engine.analyse(board, self.limit, game=board)
+            info = filtered_analysis(self.engine, board, self.limit, game=board)
             m = info["score"].pov(board.turn).mate() if "score" in info else None
             if m is not None and abs(m) <= abs(bm) and "pv" in info:
                 pv = [m.uci() for m in info["pv"]]

--- a/matetb.py
+++ b/matetb.py
@@ -19,6 +19,15 @@ def mate2score(m):
     return None
 
 
+def filtered_analysis(engine, board, limit=None, game=None):
+    info = {}
+    with engine.analysis(board, limit, game=game) as analysis:
+        for line in analysis:
+            if "score" in line and not ("upperbound" in line or "lowerbound" in line):
+                info = line
+    return info
+
+
 class MateTB:
     def __init__(self, args):
         self.fen2index = {}  # maps FENs from game tree to their index idx
@@ -231,7 +240,7 @@ class MateTB:
             if score == 0 and self.engine and ana:
                 if self.verbose >= 4:
                     print(f'Analysing "{board.epd()}" to {self.limit}.')
-                info = self.engine.analyse(board, self.limit)
+                info = filtered_analysis(self.engine, board, self.limit)
                 if "score" in info:
                     m = info["score"].pov(board.turn).mate()
                     if m:
@@ -357,7 +366,7 @@ class MateTB:
             limit = chess.engine.Limit(depth=2 * it) if it else self.limit
             if self.verbose >= 4:
                 print(f'Analysing "{board.epd()}" to {limit}.')
-            info = self.engine.analyse(board, limit)
+            info = filtered_analysis(self.engine, board, limit)
             if "score" in info:
                 m = info["score"].pov(board.turn).mate()
                 if m:

--- a/provepvs.py
+++ b/provepvs.py
@@ -22,6 +22,15 @@ def pv_status(fen, mate, pv):
     return "wrong"
 
 
+def filtered_analysis(engine, board, limit=None, game=None):
+    info = {}
+    with engine.analysis(board, limit, game=game) as analysis:
+        for line in analysis:
+            if "score" in line and not ("upperbound" in line or "lowerbound" in line):
+                info = line
+    return info
+
+
 class Analyser:
     def __init__(self, args):
         self.engine = chess.engine.SimpleEngine.popen_uci(args.engine)
@@ -75,7 +84,7 @@ class Analyser:
                     f'Analysing "{board.epd()}" (after move {board.peek().uci()}) to {limit}.',
                     flush=True,
                 )
-                info = self.engine.analyse(board, limit)
+                info = filtered_analysis(self.engine, board, limit)
                 if "score" in info:
                     score = info["score"].pov(board.turn)
                     depth = info["depth"] if "depth" in info else None
@@ -121,7 +130,7 @@ class Analyser:
                 f'Analysing "{board.epd()}" to {limit}.',
                 flush=True,
             )
-            info = self.engine.analyse(board, limit)
+            info = filtered_analysis(self.engine, board, limit)
             m, pv = None, None
             if "score" in info:
                 score = info["score"].pov(board.turn)


### PR DESCRIPTION
Apply the fix from https://github.com/vondele/matetrack/pull/79.

Otherwise lines like `info depth 25 seldepth 42 multipv 1 score mate 6 upperbound nodes 1000443 nps 3280140 hashfull 160 tbhits 0 time 305 pv h1f2` would also (and incorrectly) count as mate announcements. 