### PR TITLE
check for illegal moves in PV

### DIFF
--- a/addpvs.py
+++ b/addpvs.py
@@ -18,7 +18,10 @@ def pv_status(fen, mate, pv):
         for ply, move in enumerate(pv):
             if ply % 2 == losing_side and board.can_claim_draw():
                 return "draw"
-            board.push(chess.Move.from_uci(move))
+            uci = chess.Move.from_uci(move)
+            if not uci in board.legal_moves:
+                raise Exception(f"illegal move {move} at position {board.epd()}")
+            board.push(uci)
     except Exception as ex:
         return f'error "{ex}"'
     plies_to_checkmate = 2 * mate - 1 if mate > 0 else -2 * mate

--- a/provepvs.py
+++ b/provepvs.py
@@ -9,7 +9,10 @@ def pv_status(fen, mate, pv):
         for ply, move in enumerate(pv):
             if ply % 2 == losing_side and board.can_claim_draw():
                 return "draw"
-            board.push(chess.Move.from_uci(move))
+            uci = chess.Move.from_uci(move)
+            if not uci in board.legal_moves:
+                raise Exception(f"illegal move {move} at position {board.epd()}")
+            board.push(uci)
     except Exception as ex:
         return f'error "{ex}"'
     plies_to_checkmate = 2 * mate - 1 if mate > 0 else -2 * mate


### PR DESCRIPTION
The `board.push()` method from python chess does not check for legality. So in theory, main could miss illegal moves posted as part of a PV. This PR fixes this by explicitly checking each PV move for legality.

Main:
```
> python provepvs.py --cdbFile matetrackpv.epd -vv | grep -v ok | grep -v None
For "2brrb2/8/p7/7Q/1p1kpPp1/1P1pN1K1/3P4/8 w - - bm #2; PV: h5a5 c8d7 a5d7;" got PV status wrong.
Found 0 PVs we can use to try to prove/find mate PVs ...
All done. Saved 0 PVs to provenpvs.epd.
```

Patch:
```
> python provepvs.py --cdbFile matetrackpv.epd -vv | grep -v ok | grep -v None
For "2brrb2/8/p7/7Q/1p1kpPp1/1P1pN1K1/3P4/8 w - - bm #2; PV: h5a5 c8d7 a5d7;" got PV status error "illegal move a5d7 at position 3rrb2/3b4/p7/Q7/1p1kpPp1/1P1pN1K1/3P4/8 w - -".
Found 0 PVs we can use to try to prove/find mate PVs ...
All done. Saved 0 PVs to provenpvs.epd.
```