### PR TITLE
fix PV lengthening

### DIFF
--- a/matetb.py
+++ b/matetb.py
@@ -370,7 +370,7 @@ class MateTB:
         assert score and score > 0, f'Unexpected score {score} for "{board.epd()}".'
         newpv, it = [], 0
         while len(newpv) != len(pv) + VALUE_MATE - score:
-            limit = chess.engine.Limit(depth=2 * it) if it else self.limit
+            limit = chess.engine.Limit(depth=it) if it else self.limit
             if self.verbose >= 4:
                 print(f'Analysing "{board.epd()}" to {limit}.')
             info = filtered_analysis(self.engine, board, limit)
@@ -387,6 +387,7 @@ class MateTB:
                         newpv = pv + [m.uci() for m in info["pv"]]
                         if self.verbose >= 4:
                             print(f"New PV {newpv} has length {len(newpv)}.")
+            it += 1
         return " ".join(newpv)
 
     def output(self):


### PR DESCRIPTION
Fix an oversight in original PV lengthening code. This oversight means that an endless loop can occur, if changes to the TT mean that the engine no longer finds the earlier found mate with the specified limits.