### PR TITLE
add matestats.py script

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,7 @@ To this end the following scripts are provided:
 * `deducepvs.py`: uses proven PVs, and the associated PVs for all
   the positions along the mating lines, to find possibly missing PVs
 * `diffmates.py`: compare two Chest-like EPD files
+* `matestats.py`: generate a distribution plot for the `bm` values found in a given EPD file
 * `matetb.py`: constructs the PV for a single EPD with the help of a custom tablebase for a reduced game tree
 * `mergepvs.py`: merges several EPD files containing PVs into one
 * `provepvs.py`: uses conjectured PVs to guide a local engine to find mates and

--- a/matestats.py
+++ b/matestats.py
@@ -1,0 +1,114 @@
+import argparse, gzip, re
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+from collections import Counter
+
+
+def open_file(filename):
+    open_func = gzip.open if filename.endswith(".gz") else open
+    return open_func(filename, "rt")
+
+
+class data:
+    def __init__(self, filename, debug=False):
+        self.plies = Counter()
+        p = re.compile("([0-9a-zA-Z/\- ]*) bm #([0-9\-]*);")
+        with open_file(filename) as f:
+            for line in f:
+                m = p.match(line)
+                if not m:
+                    print("---------------------> IGNORING : ", line)
+                else:
+                    fen, bm = m.group(1), int(m.group(2))
+                    plies = 2 * bm - 1 if bm > 0 else -2 * bm
+                    self.plies[plies] += 1
+        self.filename = filename[:-3] if filename.endswith(".gz") else filename
+        print(
+            f"Loaded {sum(self.plies.values())} EPDs with abs(bm) in [{(min(self.plies.keys()) + 1) // 2}, {(max(self.plies.keys()) + 1) // 2}]."
+        )
+        s = sum(key * count for key, count in self.plies.items())
+        l = sum(self.plies.values())
+        if l:
+            print(f"Average length of bm mates in plies is {s/l:.2f}.")
+        if debug:
+            print("ply frequencies:", end=" ")
+            ply_count = sorted(self.plies.items(), key=lambda x: x[0])
+            print(", ".join([f"{ply}: {frequency}" for ply, frequency in ply_count]))
+
+    def create_graph(self, bucketSize=1, cutOff=200):
+        plies = Counter()
+        for p, freq in self.plies.items():
+            plies[min(p, cutOff)] += freq
+        rangeMin, rangeMax = min(plies.keys()), max(plies.keys())
+        fig, ax = plt.subplots()
+        ax.hist(
+            plies.keys(),
+            weights=plies.values(),
+            range=(rangeMin, rangeMax),
+            bins=(rangeMax - rangeMin) // bucketSize,
+            density=False,
+            alpha=0.5,
+            color="blue",
+            edgecolor="black",
+            align="left",
+        )
+        for patch in ax.patches:
+            bin_x = patch.get_x() + patch.get_width() / 2
+            if int(bin_x) % 2 == 0:
+                patch.set_facecolor("deepskyblue")
+        pos = mpatches.Patch(color="blue", label="bm > 0")
+        neg = mpatches.Patch(color="deepskyblue", label="bm < 0")
+        ax.legend(handles=[pos, neg])
+        ax.set_xlabel("bm")
+        fig.suptitle(
+            f"bm distribution for {self.filename}.",
+        )
+        if max(self.plies.keys()) > cutOff:
+            ax.set_title(
+                f"(Ply values > {cutOff} are included in the {cutOff} bucket.)",
+                fontsize=6,
+                family="monospace",
+            )
+        xticks = [int(x) + 1 for x in ax.get_xticks()]
+        xticks = [x for x in xticks if x >= rangeMin and x <= rangeMax and x % 2]
+        new_xtick_labels = [(x + 1) // 2 for x in xticks]
+        ax.set_xticks(xticks)
+        ax.set_xticklabels(new_xtick_labels)
+        prefix, _, _ = self.filename.rpartition(".")
+        pgnname = prefix + ".png"
+        plt.savefig(pgnname, dpi=300)
+        print(f"Saved bm distribution plot in file {pgnname}.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Plot bm distribution for positions in e.g. matetrack.epd.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "filename",
+        help=".epd(.gz) file with positions and their cdb evals.",
+    )
+    parser.add_argument(
+        "-c",
+        "--cutOff",
+        help="Cutoff value for the distribution plot (in plies).",
+        type=int,
+        default=200,
+    )
+    parser.add_argument(
+        "-b",
+        "--bucket",
+        type=int,
+        default=1,
+        help="bucket size for evals",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Show frequency data on stdout.",
+    )
+    args = parser.parse_args()
+
+    d = data(args.filename, args.debug)
+    d.create_graph(args.bucket, args.cutOff)


### PR DESCRIPTION
Sample usages:
```
> python matestats.py matetrack.epd --cutOff 50 --debug
Loaded 6554 EPDs with abs(bm) in [1, 126].
Average length of bm mates in plies is 20.15.
ply frequencies: 1: 4, 3: 17, 5: 23, 7: 67, 9: 186, 10: 1, 11: 378, 12: 4, 13: 1700, 14: 3, 15: 1020, 16: 5, 17: 671, 18: 3, 19: 585, 20: 3, 21: 401, 22: 1, 23: 331, 25: 209, 26: 1, 27: 148, 28: 1, 29: 129, 31: 100, 32: 1, 33: 75, 35: 60, 36: 1, 37: 41, 39: 45, 41: 40, 43: 26, 45: 19, 47: 23, 49: 9, 51: 16, 53: 9, 55: 8, 57: 7, 59: 23, 61: 10, 63: 10, 65: 3, 67: 6, 69: 8, 71: 5, 73: 2, 75: 4, 77: 4, 79: 4, 81: 4, 83: 4, 85: 8, 87: 3, 89: 4, 91: 3, 92: 1, 93: 4, 95: 2, 97: 2, 99: 10, 101: 2, 105: 1, 107: 1, 109: 2, 111: 2, 113: 4, 115: 1, 117: 1, 119: 4, 121: 1, 123: 2, 125: 1, 127: 4, 129: 1, 131: 2, 133: 1, 134: 1, 137: 3, 139: 1, 141: 1, 143: 3, 147: 1, 149: 1, 153: 1, 163: 1, 173: 1, 177: 1, 185: 2, 191: 1, 199: 1, 201: 1, 203: 1, 205: 1, 217: 1, 219: 1, 237: 1, 239: 1, 241: 2, 251: 1
Saved bm distribution plot in file matetrack.png.
```

```
> python matestats.py mates2000.epd --debug
Loaded 2000 EPDs with abs(bm) in [1, 27].
Average length of bm mates in plies is 15.45.
ply frequencies: 1: 1, 2: 5, 3: 7, 4: 5, 5: 5, 6: 27, 7: 22, 8: 47, 9: 34, 10: 92, 11: 62, 12: 351, 13: 281, 14: 203, 15: 136, 16: 112, 17: 100, 18: 87, 19: 66, 20: 47, 21: 47, 22: 35, 23: 38, 24: 27, 25: 26, 26: 15, 27: 19, 28: 22, 29: 16, 30: 9, 31: 8, 32: 3, 33: 10, 34: 4, 35: 4, 36: 4, 37: 4, 38: 1, 39: 3, 40: 6, 41: 3, 42: 1, 43: 1, 44: 1, 47: 1, 49: 1, 54: 1
Saved bm distribution plot in file mates2000.png.
```

![matetrack](https://github.com/user-attachments/assets/fa00d1f0-52c3-4b33-9abc-34d11fb5ed15)

![mates2000](https://github.com/user-attachments/assets/1b7dcf68-3ac9-4486-993f-2fec92b52cbe)
