### PR TITLE
add log file

### DIFF
--- a/retrocheck.py
+++ b/retrocheck.py
@@ -1,4 +1,4 @@
-import argparse, random, re, sys, concurrent.futures, chess, chess.engine, chess.syzygy
+import argparse, random, re, sys, concurrent.futures, chess, chess.engine, chess.syzygy, logging
 from time import time
 from multiprocessing import freeze_support, cpu_count
 from tqdm import tqdm
@@ -158,6 +158,10 @@ if __name__ == "__main__":
         default=["matetrackpv.epd"],
         help="file(s) containing the positions, their mate scores and a mating line",
     )
+    parser.add_argument(
+        "--logFile",
+        help="Optional file to log the engine's output while it is analysing.",
+    )
     args = parser.parse_args()
     if args.nodes is None and args.depth is None and args.time is None:
         args.nodes = 10**6
@@ -171,6 +175,10 @@ if __name__ == "__main__":
         "true",
         "false",
     ], "--syzygy50MoveRule expects True/False."
+
+    if args.logFile:
+        print(f"Logging of engine output to {args.logFile} enabled.")
+        logging.basicConfig(filename=args.logFile, level=logging.DEBUG)
 
     ana = Analyser(args)
     p = re.compile(r"([0-9a-zA-Z/\- ]*) bm #([0-9\-]*);")


### PR DESCRIPTION
Sample usage:
`python retrocheck.py --epdFile mate22pv.epd --engine ./sf16 --logFile mate22.log` gives

<details>
  <summary><code>mate22.log</code></summary>
  
```
DEBUG:asyncio:Using selector: EpollSelector
DEBUG:chess.engine:Using PidfdChildWatcher
DEBUG:chess.engine:<UciProtocol (pid=35663)>: Connection made
DEBUG:chess.engine:<UciProtocol (pid=35663)>: << uci
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> Stockfish 16 by the Stockfish developers (see AUTHORS file)
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> id name Stockfish 16
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> id author the Stockfish developers (see AUTHORS file)
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> 
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> option name Debug Log File type string default 
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> option name Threads type spin default 1 min 1 max 1024
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> option name Hash type spin default 16 min 1 max 33554432
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> option name Clear Hash type button
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> option name Ponder type check default false
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> option name MultiPV type spin default 1 min 1 max 500
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> option name Skill Level type spin default 20 min 0 max 20
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> option name Move Overhead type spin default 10 min 0 max 5000
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> option name Slow Mover type spin default 100 min 10 max 1000
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> option name nodestime type spin default 0 min 0 max 10000
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> option name UCI_Chess960 type check default false
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> option name UCI_AnalyseMode type check default false
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> option name UCI_LimitStrength type check default false
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> option name UCI_Elo type spin default 1320 min 1320 max 3190
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> option name UCI_ShowWDL type check default false
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> option name SyzygyPath type string default <empty>
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> option name SyzygyProbeDepth type spin default 1 min 1 max 100
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> option name Syzygy50MoveRule type check default true
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> option name SyzygyProbeLimit type spin default 7 min 0 max 7
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> option name Use NNUE type check default true
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> option name EvalFile type string default nn-5af11540bbfe.nnue
DEBUG:chess.engine:<UciProtocol (pid=35663)>: >> uciok
DEBUG:chess.engine:<UciProtocol (pid=35663)>: << quit
DEBUG:chess.engine:<UciProtocol (pid=35663)>: Process exited
DEBUG:chess.engine:<UciProtocol (pid=35663)>: Connection lost (exit code: 0, error: None)
DEBUG:asyncio:Using selector: EpollSelector
DEBUG:chess.engine:Using PidfdChildWatcher
DEBUG:chess.engine:<UciProtocol (pid=35679)>: Connection made
DEBUG:chess.engine:<UciProtocol (pid=35679)>: << uci
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> Stockfish 16 by the Stockfish developers (see AUTHORS file)
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> id name Stockfish 16
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> id author the Stockfish developers (see AUTHORS file)
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> 
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> option name Debug Log File type string default 
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> option name Threads type spin default 1 min 1 max 1024
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> option name Hash type spin default 16 min 1 max 33554432
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> option name Clear Hash type button
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> option name Ponder type check default false
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> option name MultiPV type spin default 1 min 1 max 500
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> option name Skill Level type spin default 20 min 0 max 20
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> option name Move Overhead type spin default 10 min 0 max 5000
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> option name Slow Mover type spin default 100 min 10 max 1000
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> option name nodestime type spin default 0 min 0 max 10000
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> option name UCI_Chess960 type check default false
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> option name UCI_AnalyseMode type check default false
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> option name UCI_LimitStrength type check default false
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> option name UCI_Elo type spin default 1320 min 1320 max 3190
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> option name UCI_ShowWDL type check default false
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> option name SyzygyPath type string default <empty>
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> option name SyzygyProbeDepth type spin default 1 min 1 max 100
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> option name Syzygy50MoveRule type check default true
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> option name SyzygyProbeLimit type spin default 7 min 0 max 7
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> option name Use NNUE type check default true
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> option name EvalFile type string default nn-5af11540bbfe.nnue
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> uciok
DEBUG:chess.engine:<UciProtocol (pid=35679)>: << setoption name UCI_AnalyseMode value true
DEBUG:chess.engine:<UciProtocol (pid=35679)>: << ucinewgame
DEBUG:chess.engine:<UciProtocol (pid=35679)>: << isready
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> readyok
DEBUG:chess.engine:<UciProtocol (pid=35679)>: << position fen 6br/1KNp1n1r/2p2p2/P1ppRP2/1kP3pP/3PBB2/PN1P4/8 w - - 0 1 moves e3c5 b4c5 d3d4 c5d4 c7b5 d4e5 b2d3 e5f5 b5d4 f5g6 d3f4 g6g7 d4f5 g7f8 f4g6 f8e8 b7c8 g4f3 a5a6 f3f2 a6a7 f2f1q a7a8n f1f4 a8c7 f4c7 c8c7 d5c4 c7c8 d7d5 a2a4 c4c3 d2c3 c6c5 a4a5 d5d4 a5a6 d4d3 a6a7 d3d2 a7a8n d2d1q
DEBUG:chess.engine:<UciProtocol (pid=35679)>: << go nodes 100000
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> info string NNUE evaluation using nn-5af11540bbfe.nnue enabled
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> info depth 1 seldepth 1 multipv 1 score mate 1 nodes 27 nps 27000 hashfull 0 tbhits 0 time 1 pv a8c7
.
.
.
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> info depth 16 seldepth 29 multipv 1 score cp 82 nodes 449540 nps 497829 hashfull 147 tbhits 0 time 903 pv e5e8 f7d6 b7b6 d5d4 e8b8 g8c4 a2a3 b4b3 b8h8 h7h8 b2c4 d6c4 d3c4 g4f3 e3f2 b3c4 a5a6 h8b8 b6a5 b8g8 a6a7 c4d3 c7a6 d3d2 a6b8
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> info depth 17 seldepth 29 multipv 1 score cp 81 nodes 653686 nps 493720 hashfull 215 tbhits 0 time 1324 pv e5e8 f7d6 b7b6 d5d4 e8b8 g8c4 a2a3 b4b3 b8h8 h7h8 b2c4 d6c4 d3c4 g4f3 e3f2 b3c4 a5a6 h8b8 b6a5 c4d3 a6a7 b8d8 h4h5 c5c4 c7a6 c4c3 d2c3 d4c3
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> info depth 18 seldepth 31 multipv 1 score cp 73 nodes 963940 nps 499968 hashfull 308 tbhits 0 time 1928 pv e5e8 f7d6 b7b6 d5d4 e8b8 g8c4 b8h8 h7h8 a2a3 b4b3 b2c4 g4f3 e3f2 d6c4 d3c4 b3c4 a5a6 h8b8 b6a5 c4d3 a6a7 b8d8 h4h5 c5c4 c7a6 c4c3 d2c3 d4c3
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> info depth 19 seldepth 30 multipv 1 score cp 73 nodes 1001159 nps 501834 hashfull 318 tbhits 0 time 1995 pv e5e8 f7d6 b7b6 d5d4 e8b8 g8c4 b8h8 h7h8 a2a3 b4b3 b2c4 g4f3 e3f2 d6c4 d3c4 b3c4 a5a6 h8b8 b6a5 c4d3 a6a7 b8d8 h4h5 c5c4 c7a6 c4c3 d2c3 d4c3 a6b4 d3e2
DEBUG:chess.engine:<UciProtocol (pid=35679)>: >> bestmove e5e8 ponder f7d6
DEBUG:chess.engine:<UciProtocol (pid=35679)>: << quit
DEBUG:chess.engine:<UciProtocol (pid=35679)>: Process exited
DEBUG:chess.engine:<UciProtocol (pid=35679)>: Connection lost (exit code: 0, error: None)
```
</detail>